### PR TITLE
Feat: add 'Opener' section content

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
     <header>
         <!-- Opener -->
         <section id="opener">
+            <div>
+                <h3>Embark on an extraordinary expedition with Thornberry Adventures.</h3>
+                <h1>Dare to walk on the wild side?</h1>
+                <button>Contact</button>
+            </div>
         </section>
     </header>
     <main>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <div>
                 <h3>Embark on an extraordinary expedition with Thornberry Adventures.</h3>
                 <h1>Dare to walk on the wild side?</h1>
-                <button>Contact</button>
+                <a href="#contact" class="button">Contact</a>
             </div>
         </section>
     </header>


### PR DESCRIPTION
closes: #4 
I went with `<h3>` for the 'Embark' text as I figure this section has the main `<h1>` title, and other sections have smaller `<h2>` titles. This seems like the next-most-prominent text after that?